### PR TITLE
Fix intrusive_list::erase() and add unit tests

### DIFF
--- a/libfplutil/include/fplutil/intrusive_list.h
+++ b/libfplutil/include/fplutil/intrusive_list.h
@@ -367,21 +367,16 @@ class intrusive_list {
   }
 
   iterator erase(iterator pos) {
-    node_type* next = pos.node_->next_;
-    pos.node_->remove();
+    iterator next = iterator(pos.value_->next_, node_offset_);
+    pos.value_->remove();
     return next;
   }
 
   iterator erase(iterator first, iterator last) {
-    node_type* before_first = first.node_->previous_;
-    node_type* after_last = last.node_->next_;
-    after_last->previous_ = before_first;
-    before_first->next_ = after_last;
-
     iterator iter = first;
     while (iter != last) {
       iterator current = iter++;
-      current.node_->clear();
+      current.value_->remove();
     }
     return iter;
   }

--- a/libfplutil/unit_tests/test_intrusive_list/test_intrusive_list.cc
+++ b/libfplutil/unit_tests/test_intrusive_list/test_intrusive_list.cc
@@ -293,6 +293,32 @@ TEST_F(intrusive_list_test, crbegin_crend) {
   EXPECT_EQ(list_.crend(), iter);
 }
 
+TEST_F(intrusive_list_test, erase) {
+  EXPECT_TRUE(list_.empty());
+
+  list_.push_back(one_);
+  list_.push_back(two_);
+  EXPECT_EQ(1, list_.begin()->value());
+  list_.erase(list_.begin());
+  EXPECT_EQ(2, list_.begin()->value());
+  EXPECT_EQ(1, list_.size());
+
+  list_.push_back(one_);
+  list_.erase(list_.begin(), list_.end());
+  EXPECT_TRUE(list_.empty());
+  EXPECT_EQ(0, list_.size());
+
+  list_.push_back(one_);
+  list_.push_back(two_);
+  list_.push_back(three_);
+  auto begin = list_.begin();
+  auto end = --list_.end();
+  EXPECT_EQ(3, end->value());
+  list_.erase(begin, end);
+  EXPECT_EQ(3, list_.begin()->value());
+  EXPECT_EQ(1, list_.size());
+}
+
 TEST_F(intrusive_list_test, clear) {
   EXPECT_TRUE(list_.empty());
 


### PR DESCRIPTION
erase() was referencing a non-existant iterator 'node_' member and
erase(first, last) was incorrectly updating a list's embedded link
element. Fix and add unit tests.